### PR TITLE
properly detect systemd > 208

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ add_feature_info("Wayland-Egl" Wayland_Egl_FOUND "Required for the compositor")
 find_package(QtWaylandScanner REQUIRED)
 
 # systemd
-pkg_check_modules(systemd libsystemd-daemon)
+pkg_check_modules(systemd libsystemd)
 if(systemd_FOUND)
     set(HAVE_SYSTEMD 1)
 endif()


### PR DESCRIPTION
libsystem-daemon was merged to libsystem on systemd 208->209

see systemd commit
commit 0ebee8818404adb95a0b8a01416aad3a16f64ae1
Author: Kay Sievers <kay@vrfy.org>
Date:   Tue Feb 18 18:50:11 2014 +0100

    build-sys: merge libsystemd-daemon into libsystemd

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>