### PR TITLE
properly detect systemd > 208

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,12 @@ find_package(QtWaylandScanner REQUIRED)
 pkg_check_modules(systemd libsystemd-daemon)
 if(systemd_FOUND)
     set(HAVE_SYSTEMD 1)
+else()
+    # libsystem-daemon was merged to libsystem on systemd 208->209
+    pkg_check_modules(systemd libsystemd)
+    if(systemd_FOUND)
+        set(HAVE_SYSTEMD 1)
+    endif()
 endif()
 add_feature_info("systemd" systemd_FOUND "Required for systemd integration")
 

--- a/src/libgreenisland/CMakeLists.txt
+++ b/src/libgreenisland/CMakeLists.txt
@@ -103,7 +103,6 @@ else()
 endif()
 
 if(systemd_FOUND)
-    set_target_properties(GreenIsland PROPERTIES LINK_FLAGS -L${systemd_LIBDIR})
     target_link_libraries(GreenIsland ${systemd_LIBRARIES})
 endif()
 


### PR DESCRIPTION
libsystem-daemon was merged to libsystem on systemd 208->209

see systemd commit
commit 0ebee8818404adb95a0b8a01416aad3a16f64ae1
Author: Kay Sievers <kay@vrfy.org>
Date:   Tue Feb 18 18:50:11 2014 +0100

    build-sys: merge libsystemd-daemon into libsystemd

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>