### PR TITLE
do not require wayland-egl explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,12 @@ set_package_properties(EGL PROPERTIES
 
 # Wayland
 set(REQUIRED_WAYLAND_VERSION 1.2.0)
-find_package(Wayland ${REQUIRED_WAYLAND_VERSION} COMPONENTS Client Server Egl)
+find_package(Wayland ${REQUIRED_WAYLAND_VERSION} COMPONENTS Client Server)
 set_package_properties(Wayland PROPERTIES
     TYPE REQUIRED
     PURPOSE "Required to build Green Island")
 add_feature_info("Wayland-Client" Wayland_Client_FOUND "Required for protocols")
 add_feature_info("Wayland-Server" Wayland_Server_FOUND "Required for protocols")
-add_feature_info("Wayland-Egl" Wayland_Egl_FOUND "Required for the compositor")
 
 # Wayland and QtWayland scanner
 find_package(QtWaylandScanner REQUIRED)

--- a/src/libgreenisland/CMakeLists.txt
+++ b/src/libgreenisland/CMakeLists.txt
@@ -92,7 +92,6 @@ target_link_libraries(GreenIsland
     KF5::Screen
     Wayland::Client
     Wayland::Server
-    Wayland::Egl
     EGL::EGL
 )
 


### PR DESCRIPTION
* found no signs of making wayland-egl a requirement
* backgound: ecm does not find wayland-egl in case the library is not named
  libwayland-egl.so*. Yocto's meta-fsl-arm ships egl-library containing
  wayland-egl together with a correct pkg-config. This is a correct approach
  but fails for ecm.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>