### PR TITLE
Fix error during compilation on Arch Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 *.user
+*~

--- a/src/libgreenisland/protocols/plasma/plasmasurface.cpp
+++ b/src/libgreenisland/protocols/plasma/plasmasurface.cpp
@@ -181,7 +181,7 @@ void PlasmaSurface::surface_set_output(Resource *resource,
     QWaylandOutput *oldOutput = m_surface->output();
     QWaylandOutput *newOutput = QWaylandOutput::fromResource(outputResource);
     QWaylandOutputChangedEvent e(oldOutput, newOutput);
-    QCoreApplication::sendEvent(m_surface, &e);
+    QCoreApplication::sendEvent(m_surface, (QEvent *) &e);
     Q_EMIT m_window->outputChanged();
 }
 


### PR DESCRIPTION
Make fails because it is unable to automatically cast
QWaylandOutputChangedEvent * to QEvent *. Adding a manual cast fixes
this problem.

* Add a cast to QEvent * to fix error during compilation
* Add temp files ending in ~ to the .gitignore