### PR TITLE
Add optional use of KDeclarative to OutputWindow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 # Options
 option(ENABLE_OPENGL "Enable OpenGL support" OFF)
+option(ENABLE_KDECLARATIVE "Enable KDeclarative support" OFF)
 
 # Set version
 set(PROJECT_VERSION "0.5.90")
@@ -61,7 +62,14 @@ find_package(Qt5 ${REQUIRED_QT_VERSION} CONFIG REQUIRED DBus Gui Qml Quick Widge
 
 # Find KF5
 set(REQUIRED_KF5_VERSION 5.2.0)
-find_package(KF5 ${REQUIRED_KF5_VERSION} REQUIRED COMPONENTS Screen)
+
+# Use KDeclarative if requested
+if(ENABLE_KDECLARATIVE)
+    add_definitions(-DENABLE_KDECLARATIVE)
+    find_package(KF5 ${REQUIRED_KF5_VERSION} REQUIRED COMPONENTS Screen Declarative)
+else()
+    find_package(KF5 ${REQUIRED_KF5_VERSION} REQUIRED COMPONENTS Screen)
+endif()
 
 # GL requirements
 if(${Qt5Gui_OPENGL_IMPLEMENTATION} STREQUAL "GL")

--- a/src/libgreenisland/CMakeLists.txt
+++ b/src/libgreenisland/CMakeLists.txt
@@ -91,18 +91,34 @@ add_library(GreenIsland SHARED ${SOURCES})
 generate_export_header(GreenIsland EXPORT_FILE_NAME greenisland/greenisland_export.h)
 add_library(GreenIsland::GreenIsland ALIAS GreenIsland)
 
-target_link_libraries(GreenIsland
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Gui
-    Qt5::Widgets
-    Qt5::Quick
-    Qt5::Compositor
-    KF5::Screen
-    Wayland::Client
-    Wayland::Server
-    EGL::EGL
-)
+if(ENABLE_KDECLARATIVE)
+    target_link_libraries(GreenIsland
+        Qt5::Core
+        Qt5::DBus
+        Qt5::Gui
+        Qt5::Widgets
+        Qt5::Quick
+        Qt5::Compositor
+        KF5::Screen
+        KF5::Declarative
+        Wayland::Client
+        Wayland::Server
+        EGL::EGL
+    )
+else()
+    target_link_libraries(GreenIsland
+        Qt5::Core
+        Qt5::DBus
+        Qt5::Gui
+        Qt5::Widgets
+        Qt5::Quick
+        Qt5::Compositor
+        KF5::Screen
+        Wayland::Client
+        Wayland::Server
+        EGL::EGL
+    )
+endif()
 
 if(${Qt5Gui_OPENGL_IMPLEMENTATION} STREQUAL "GL")
     target_link_libraries(GreenIsland ${OPENGL_LIBRARIES})

--- a/src/libgreenisland/outputwindow.cpp
+++ b/src/libgreenisland/outputwindow.cpp
@@ -27,6 +27,10 @@
 #include <QtCore/QStandardPaths>
 #include <QtQml/QQmlContext>
 
+#ifdef ENABLE_KDECLARATIVE
+#include <KDeclarative/KDeclarative>
+#endif
+
 #include "compositor.h"
 #include "gldebug.h"
 #include "globalregistry.h"
@@ -105,6 +109,14 @@ void OutputWindow::setOutput(Output *output)
 
     // Add a context property to reference the output
     rootContext()->setContextProperty("_greenisland_output", m_output);
+
+    #ifdef ENABLE_KDECLARATIVE
+    KDeclarative::KDeclarative kdeclarative;
+
+    kdeclarative.setDeclarativeEngine(engine());
+    kdeclarative.initialize();
+    kdeclarative.setupBindings();
+    #endif
 
     // Load QML and setup window
     setResizeMode(QQuickView::SizeRootObjectToView);


### PR DESCRIPTION
This is useful if a developer wants to use KI18n, KUser, or the desktop icon theme provider.