### PR TITLE
Update the launcher to use the new --shell argument

### DIFF
--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     processController.setFullScreenShellEnabled(parser.isSet(fullScreenShellOption));
 
     // Pass additional arguments
-    processController.setPlugin(parser.value(shellOption));
+    processController.setShell(parser.value(shellOption));
 
     // Start the compositor
     processController.start();

--- a/src/launcher/processcontroller.cpp
+++ b/src/launcher/processcontroller.cpp
@@ -82,14 +82,14 @@ void ProcessController::setFullScreenShellEnabled(bool value)
     }
 }
 
-QString ProcessController::plugin() const
+QString ProcessController::shell() const
 {
-    return m_plugin;
+    return m_shell;
 }
 
-void ProcessController::setPlugin(const QString &plugin)
+void ProcessController::setShell(const QString &shell)
 {
-    m_plugin = plugin;
+    m_shell = shell;
 }
 
 void ProcessController::start()
@@ -146,9 +146,9 @@ void ProcessController::startCompositor()
         env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("xcb"));
     }
 
-    if (!m_plugin.isEmpty())
+    if (!m_shell.isEmpty())
         m_compositor->setArguments(m_compositor->arguments()
-                                   << QStringLiteral("-p") << m_plugin);
+                                   << QStringLiteral("--shell") << m_shell);
 
     // Start the process
     qDebug() << "Running:" << qPrintable(m_compositor->program())

--- a/src/launcher/processcontroller.h
+++ b/src/launcher/processcontroller.h
@@ -35,14 +35,17 @@ class QFileSystemWatcher;
 class ProcessController : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY(QString shell READ shell WRITE setShell)
+
 public:
     explicit ProcessController(QObject *parent = Q_NULLPTR);
 
     bool isFullScreenShellEnabled() const;
     void setFullScreenShellEnabled(bool value);
 
-    QString plugin() const;
-    void setPlugin(const QString &plugin);
+    QString shell() const;
+    void setShell(const QString &plugin);
 
     void start();
 
@@ -56,7 +59,7 @@ private:
     QString m_fullScreenShellSocket;
     QFileSystemWatcher *m_fullScreenShellWatcher;
 
-    QString m_plugin;
+    QString m_shell;
 
     QString randomString() const;
 


### PR DESCRIPTION
Currently, the `greenisland-launcher` command doesn't work because it
uses the old `-p` argument to launch `greenisland`.

* Pass the shell as the `--shell` argument, instead of the old `--plugin`
* Mark `shell` as a `Q_PROPERTY`