### PR TITLE
Detect the fake screen configuration from the running desktop environment

### DIFF
--- a/src/compositor/main.cpp
+++ b/src/compositor/main.cpp
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2014 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:GPL2+$
  *
@@ -96,11 +98,7 @@ int main(int argc, char *argv[])
 
     // Use default fake screen data on X11
     if (qEnvironmentVariableIsSet("DISPLAY") && homeApp.fakeScreenData().isEmpty()) {
-        const QString fileName = QString("greenisland/screen-data/one-1920x1080.json");
-        QString path = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
-                                              fileName);
-        if (!path.isEmpty())
-            homeApp.setFakeScreenData(path);
+        homeApp.setDetectFakeScreen(true);
     }
 
     // Idle timer

--- a/src/libgreenisland/compositor.cpp
+++ b/src/libgreenisland/compositor.cpp
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -112,6 +114,12 @@ void Compositor::setFakeScreenConfiguration(const QString &fileName)
 {
     Q_D(Compositor);
     d->fakeScreenConfiguration = fileName;
+}
+
+void Compositor::setDetectFakeScreen(bool detectFakeScreen)
+{
+    Q_D(Compositor);
+    d->detectFakeScreen = detectFakeScreen;
 }
 
 bool Compositor::isRunning() const
@@ -268,7 +276,8 @@ void Compositor::run()
         // Queue screen configuration acquisition
         QMetaObject::invokeMethod(d->screenManager, "acquireConfiguration",
                                   Qt::QueuedConnection,
-                                  Q_ARG(QString, d->fakeScreenConfiguration));
+                                  Q_ARG(QString, d->fakeScreenConfiguration),
+                                  Q_ARG(bool, d->detectFakeScreen));
     }
 }
 

--- a/src/libgreenisland/compositor.h
+++ b/src/libgreenisland/compositor.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -75,6 +77,7 @@ public:
     static Compositor *instance();
 
     void setFakeScreenConfiguration(const QString &fileName);
+    void setDetectFakeScreen(bool detectFakeScreen);
 
     bool isRunning() const;
 

--- a/src/libgreenisland/compositor_p.h
+++ b/src/libgreenisland/compositor_p.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -111,6 +113,8 @@ public:
     QWaylandSurface *lastKeyboardFocus;
 
     QString fakeScreenConfiguration;
+    bool detectFakeScreen;
+
     CompositorSettings *settings;
     ScreenManager *screenManager;
     GreenIslandRecorderManager *recorderManager;
@@ -147,4 +151,3 @@ protected:
 }
 
 #endif // COMPOSITOR_P_H
-

--- a/src/libgreenisland/homeapplication.cpp
+++ b/src/libgreenisland/homeapplication.cpp
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -79,6 +81,16 @@ void HomeApplication::setFakeScreenData(const QString &fileName)
     m_fakeScreenFileName = fileName;
 }
 
+bool HomeApplication::detectFakeScreen() const
+{
+    return m_detectFakeScreen;
+}
+
+void HomeApplication::setDetectFakeScreen(bool detectFakeScreen)
+{
+    m_detectFakeScreen = detectFakeScreen;
+}
+
 int HomeApplication::idleTime() const
 {
     return m_idleTime;
@@ -151,6 +163,8 @@ bool HomeApplication::run(const QString &shell)
     Compositor *compositor = Compositor::instance();
     if (!m_fakeScreenFileName.isEmpty())
         compositor->setFakeScreenConfiguration(m_fakeScreenFileName);
+    else
+        compositor->setDetectFakeScreen(m_detectFakeScreen);
     QObject::connect(compositor, &Compositor::screenConfigurationAcquired, [this] {
 #if HAVE_SYSTEMD
         // Notify systemd when the screen configuration is ready

--- a/src/libgreenisland/homeapplication.h
+++ b/src/libgreenisland/homeapplication.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2012-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -49,6 +51,9 @@ public:
     QString fakeScreenData() const;
     void setFakeScreenData(const QString &fileName);
 
+    bool detectFakeScreen() const;
+    void setDetectFakeScreen(bool detectFakeScreen);
+
     int idleTime() const;
     void setIdleTime(int time);
 
@@ -60,6 +65,7 @@ public:
 protected:
     QString m_socket;
     QString m_fakeScreenFileName;
+    bool m_detectFakeScreen;
     int m_idleTime;
     bool m_notify;
 
@@ -69,4 +75,3 @@ protected:
 } // namespace GreenIsland
 
 #endif // HOMEAPPLICATION_H
-

--- a/src/libgreenisland/screen/fakescreenbackend.cpp
+++ b/src/libgreenisland/screen/fakescreenbackend.cpp
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -61,6 +63,13 @@ void FakeScreenBackend::loadConfiguration(const QString &fileName)
     m_config = ScreenConfiguration::parseJson(file.readAll());
 
     file.close();
+}
+
+void FakeScreenBackend::detectConfiguration()
+{
+    qCDebug(FAKE_BACKEND) << "Detecting configuration from existing desktop environment";
+
+    m_config = ScreenConfiguration::detectConfiguration();
 }
 
 void FakeScreenBackend::acquireConfiguration()

--- a/src/libgreenisland/screen/fakescreenbackend.h
+++ b/src/libgreenisland/screen/fakescreenbackend.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -44,6 +46,7 @@ public:
     ~FakeScreenBackend();
 
     void loadConfiguration(const QString &fileName);
+    void detectConfiguration();
 
 public Q_SLOTS:
     void acquireConfiguration();

--- a/src/libgreenisland/screen/screenconfiguration.cpp
+++ b/src/libgreenisland/screen/screenconfiguration.cpp
@@ -195,12 +195,11 @@ ScreenConfiguration *ScreenConfiguration::parseJson(const QByteArray &data)
 ScreenConfiguration *ScreenConfiguration::detectConfiguration()
 {
     ScreenConfiguration *config = new ScreenConfiguration;
-    int titleBarHeight = 50; // Hardcoded since we can't detect it
 
     Q_FOREACH(QScreen *screen, QGuiApplication::screens()) {
         ScreenOutput::Mode mode;
         mode.size = QSize(screen->availableGeometry().width(),
-                screen->availableGeometry().height() - titleBarHeight);
+                screen->availableGeometry().height());
         mode.refreshRate = screen->refreshRate() * 1000;
 
         QPoint pos(screen->availableGeometry().x(), screen->availableGeometry().y());

--- a/src/libgreenisland/screen/screenconfiguration.h
+++ b/src/libgreenisland/screen/screenconfiguration.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -86,6 +88,7 @@ public:
     QList<ScreenOutput *> outputs() const;
 
     static ScreenConfiguration *parseJson(const QByteArray &data);
+    static ScreenConfiguration *detectConfiguration();
 
 private:
     QList<ScreenOutput *> m_outputs;

--- a/src/libgreenisland/screen/screenmanager.cpp
+++ b/src/libgreenisland/screen/screenmanager.cpp
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2014-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -49,14 +51,14 @@ ScreenManager::ScreenManager(Compositor *compositor)
 {
 }
 
-void ScreenManager::acquireConfiguration(const QString &fileName)
+void ScreenManager::acquireConfiguration(const QString &fileName, bool detectFakeScreen)
 {
     if (m_backend) {
         qCWarning(GREENISLAND_COMPOSITOR) << "Cannot change backend at runtime!";
         return;
     }
 
-    if (fileName.isEmpty())
+    if (fileName.isEmpty() && !detectFakeScreen)
         m_backend = new NativeScreenBackend(m_compositor, this);
     else
         m_backend = new FakeScreenBackend(m_compositor, this);
@@ -72,6 +74,8 @@ void ScreenManager::acquireConfiguration(const QString &fileName)
 
     if (!fileName.isEmpty())
         static_cast<FakeScreenBackend *>(m_backend)->loadConfiguration(fileName);
+    else if (detectFakeScreen)
+        static_cast<FakeScreenBackend *>(m_backend)->detectConfiguration();
 
     m_backend->acquireConfiguration();
 }

--- a/src/libgreenisland/screen/screenmanager.h
+++ b/src/libgreenisland/screen/screenmanager.h
@@ -2,9 +2,11 @@
  * This file is part of Green Island.
  *
  * Copyright (C) 2014-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
  *
  * Author(s):
  *    Pier Luigi Fiorini
+ *    Michael Spencer
  *
  * $BEGIN_LICENSE:LGPL2.1+$
  *
@@ -42,7 +44,7 @@ public:
     ScreenManager(Compositor *compositor);
 
 public Q_SLOTS:
-    void acquireConfiguration(const QString &fileName = QString());
+    void acquireConfiguration(const QString &fileName = QString(), bool detectFakeScreen = false);
 
 Q_SIGNALS:
     void configurationAcquired();


### PR DESCRIPTION
This uses QScreen to create a fake screen configuration, with one fake screen per real screen, removing height for system panels and the window title bar. There isn't a way to detect the window title bar height, so it is hardcoded at 50 pixels.
