### PR TITLE
Fix build broken in 5727fde by using the old BASENAME in header files for fullscreen-shell

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -39,7 +39,7 @@ greenisland_add_client_protocol(SOURCES
 )
 greenisland_add_client_protocol(SOURCES
     PROTOCOL ${WAYLAND_PROTOCOLS_DIR}/unstable/fullscreen-shell/fullscreen-shell-unstable-v1.xml
-    BASENAME fullscreen-shell-unstable-v1
+    BASENAME fullscreen-shell
     PREFIX zwp_
 )
 greenisland_add_client_protocol(SOURCES


### PR DESCRIPTION
You either need to apply this patch or change every file that uses the new header file names.
