### PR TITLE
platform: add egl source files for GLES qt not GL

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SOURCES
     platformcompositor/openglcompositor.cpp
 )
 
-if(${Qt5Gui_OPENGL_IMPLEMENTATION} STREQUAL "GL")
+if(NOT ${Qt5Gui_OPENGL_IMPLEMENTATION} STREQUAL "GL")
     set(SOURCES
         ${SOURCES}
         eglconvenience/eglpbuffer.cpp


### PR DESCRIPTION
Please check - I am not sure this is correct. It works for me but..

with GLESv2 I get:

| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:68: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::eglDisplay() const'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:69: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::eglDisplay() const'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:59: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::createTemporaryOffscreenSurface()'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:77: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::eglDisplay() const'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:93: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::swapBuffers(QPlatformSurface*)'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.cpp:75: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::destroyTemporaryOffscreenSurface(void*)'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.h:38: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::~EGLPlatformContext()'
| /usr/src/greenisland/src/platform/deviceintegration/eglfscontext.h:38: error: undefined reference to 'GreenIsland::Platform::EGLPlatformContext::~EGLPlatformContext()'
...

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>