### PR TITLE
RaspberryPi: Don't suggest closed source gles driver when using open …

### DIFF
--- a/cmake/FindBcmHost.cmake
+++ b/cmake/FindBcmHost.cmake
@@ -90,6 +90,8 @@ find_package_handle_standard_args(BcmHost
 if(BcmHost_FOUND)
     set(BcmHost_LIBRARY_DIRS "${BcmHost_PREFIX}/lib")
     set(BcmHost_INCLUDE_DIR ${BcmHost_INCLUDE_DIR} ${BcmHost_INCLUDE_DIR}/interface ${BcmHost_INCLUDE_DIR}/interface/vcos/pthreads)
+else()
+    add_definitions(-DWITHOUT_BRCM)
 endif()
 
 if(BcmHost_FOUND)

--- a/src/platform/deviceintegration/deviceintegration_p.cpp
+++ b/src/platform/deviceintegration/deviceintegration_p.cpp
@@ -56,6 +56,7 @@ public:
         if (!qEnvironmentVariableIsEmpty("DISPLAY"))
             return QStringLiteral("x11");
 
+#ifndef WITHOUT_BRCM
         // Detect Broadcom
         bool found = deviceModel().startsWith(QLatin1String("Raspberry"));
         if (!found) {
@@ -67,6 +68,7 @@ public:
         }
         if (found)
             return QStringLiteral("brcm");
+#endif
 
         // TODO: Detect Mali
         // TODO: Detect Vivante


### PR DESCRIPTION
…source

When building greenisland for RaspberryPi with open source GL drivers
(mesa/vc4), cmake does not find closed source drivers (which is correct)

| -- The following OPTIONAL packages have not been found:
|
| \* BcmHost , Broadcom OpenGLES graphics libraries. , http://www.broadcom.com/

But launching a hawaii session reports:

| greenisland.qpa.deviceintegration: Preferred EGL device integration based on the hardware configuration: "brcm"

which does not make sense - there were no integration libs built for closed
source RaspberryPi GLES.

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
