### PR TITLE
waylandcompositor: fix non GL (GLES) builds

### DIFF
--- a/src/waylandcompositor/compositor_api/qwaylandquickcompositor.cpp
+++ b/src/waylandcompositor/compositor_api/qwaylandquickcompositor.cpp
@@ -156,7 +156,9 @@ void QWaylandQuickCompositor::grabSurface(QWaylandSurfaceGrabber *grabber, const
             glGenTextures(1, &texture);
             glBindTexture(GL_TEXTURE_2D, texture);
             glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+#ifdef QT_WAYLAND_COMPOSITOR_GL
             buffer.bindToTexture();
+#endif
             blitter.blit(texture, QMatrix4x4(), surfaceOrigin);
 
             blitter.release();

--- a/src/waylandcompositor/compositor_api/qwaylandquickitem.cpp
+++ b/src/waylandcompositor/compositor_api/qwaylandquickitem.cpp
@@ -311,7 +311,9 @@ public:
                 GLuint texture;
                 glGenTextures(1, &texture);
                 glBindTexture(GL_TEXTURE_2D, texture);
+#ifdef QT_WAYLAND_COMPOSITOR_GL
                 buffer.bindToTexture();
+#endif
                 m_sgTex = surfaceItem->window()->createTextureFromId(texture , QSize(surfaceItem->width(), surfaceItem->height()), opt);
             }
         }
@@ -1122,14 +1124,20 @@ QSGNode *QWaylandQuickItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeDat
 
         if (d->newTexture) {
             d->newTexture = false;
+#ifdef QT_WAYLAND_COMPOSITOR_GL
             for (int plane = 0; plane < bufferTypes[ref.bufferFormatEgl()].planeCount; plane++)
                 if (uint texture = ref.textureForPlane(plane))
                     material->setTextureForPlane(plane, texture);
+#endif
             material->bind();
+#ifdef QT_WAYLAND_COMPOSITOR_GL
             ref.bindToTexture();
+#endif
         }
 
+#ifdef QT_WAYLAND_COMPOSITOR_GL
         ref.updateTexture();
+#endif
         QSGGeometry::updateTexturedRectGeometry(geometry, rect, QRectF(0, 0, 1, 1));
 
         node->setGeometry(geometry);


### PR DESCRIPTION
qwaylandquickcompositor.cpp:159:20: error: 'class QWaylandBufferRef' has no member named 'bindToTexture'
             buffer.bindToTexture();
                    ^~~~~~~~~~~~~

qwaylandquickitem.cpp:314:24: error: 'const class QWaylandBufferRef' has no member named 'bindToTexture'
                 buffer.bindToTexture();
                        ^~~~~~~~~~~~~

qwaylandquickitem.cpp:1126:40: error: 'class QWaylandBufferRef' has no member named 'textureForPlane'
                 if (uint texture = ref.textureForPlane(plane))
                                        ^~~~~~~~~~~~~~~

qwaylandquickitem.cpp:1129:17: error: 'class QWaylandBufferRef' has no member named 'bindToTexture'
             ref.bindToTexture();
                 ^~~~~~~~~~~~~

qwaylandquickitem.cpp:1132:13: error: 'class QWaylandBufferRef' has no member named 'updateTexture'
         ref.updateTexture();
             ^~~~~~~~~~~~~

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
